### PR TITLE
Add @newriive/common-types package with shared types, samples, and tests

### DIFF
--- a/packages/common-types/README.md
+++ b/packages/common-types/README.md
@@ -1,0 +1,18 @@
+# Common Types
+
+This package contains TypeScript types and interfaces shared across multiple lambdas and packages in the Newriive monorepo.
+
+## Usage
+
+Import types from this package in your code:
+
+```ts
+import type { MyType } from '@newriive/common-types';
+```
+
+## Development
+
+- Add types/interfaces in `src/`
+- Add tests in `tests/`
+- Run `pnpm build` to compile
+- Run `pnpm test` to test

--- a/packages/common-types/package.json
+++ b/packages/common-types/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@newriive/common-types",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "jest": "^29.0.0",
+    "@types/jest": "^29.0.0"
+  }
+}

--- a/packages/common-types/src/checklist-group.ts
+++ b/packages/common-types/src/checklist-group.ts
@@ -1,0 +1,7 @@
+export type ChecklistGroup = {
+  id: string;
+  userId: string;
+  name: string; // e.g., "Visa Process"
+  description?: string;
+  createdAt: string;
+};

--- a/packages/common-types/src/checklist-item.ts
+++ b/packages/common-types/src/checklist-item.ts
@@ -1,0 +1,10 @@
+export type ChecklistItem = {
+  id: string;
+  userId: string;
+  groupId: string; // Foreign key to ChecklistGroup
+  title: string;
+  notes?: string;
+  dueDate?: string;
+  completed: boolean;
+  createdAt: string;
+};

--- a/packages/common-types/src/index.ts
+++ b/packages/common-types/src/index.ts
@@ -1,0 +1,3 @@
+export * from './user';
+export * from './checklist-group';
+export * from './checklist-item';

--- a/packages/common-types/src/user.ts
+++ b/packages/common-types/src/user.ts
@@ -1,0 +1,6 @@
+export type User = {
+  id: string;
+  email?: string;
+  name?: string;
+  createdAt?: string;
+};

--- a/packages/common-types/tests/checklist-group.sample.json
+++ b/packages/common-types/tests/checklist-group.sample.json
@@ -1,0 +1,7 @@
+{
+  "id": "group-1",
+  "userId": "user-1",
+  "name": "Visa Process",
+  "description": "Steps for visa application",
+  "createdAt": "2025-06-19T00:00:00Z"
+}

--- a/packages/common-types/tests/checklist-item.sample.json
+++ b/packages/common-types/tests/checklist-item.sample.json
@@ -1,0 +1,10 @@
+{
+  "id": "item-1",
+  "userId": "user-1",
+  "groupId": "group-1",
+  "title": "Submit application",
+  "notes": "Remember to include all documents.",
+  "dueDate": "2025-07-01T00:00:00Z",
+  "completed": false,
+  "createdAt": "2025-06-19T00:00:00Z"
+}

--- a/packages/common-types/tests/index.test.ts
+++ b/packages/common-types/tests/index.test.ts
@@ -1,0 +1,25 @@
+import { User, ChecklistGroup, ChecklistItem } from '../src';
+import userSample from './user.sample.json';
+import groupSample from './checklist-group.sample.json';
+import itemSample from './checklist-item.sample.json';
+
+describe('Common Types', () => {
+  it('User sample matches User type', () => {
+    const user: User = userSample;
+    expect(user.id).toBe('user-1');
+    expect(user.email).toBe('user1@example.com');
+  });
+
+  it('ChecklistGroup sample matches ChecklistGroup type', () => {
+    const group: ChecklistGroup = groupSample;
+    expect(group.id).toBe('group-1');
+    expect(group.name).toBe('Visa Process');
+  });
+
+  it('ChecklistItem sample matches ChecklistItem type', () => {
+    const item: ChecklistItem = itemSample;
+    expect(item.id).toBe('item-1');
+    expect(item.title).toBe('Submit application');
+    expect(item.completed).toBe(false);
+  });
+});

--- a/packages/common-types/tests/user.sample.json
+++ b/packages/common-types/tests/user.sample.json
@@ -1,0 +1,6 @@
+{
+  "id": "user-1",
+  "email": "user1@example.com",
+  "name": "Test User",
+  "createdAt": "2025-06-19T00:00:00Z"
+}

--- a/packages/common-types/tsconfig.json
+++ b/packages/common-types/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,18 @@ importers:
         specifier: ^5.0.0
         version: 5.8.3
 
+  packages/common-types:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.0.0
+        version: 29.5.14
+      jest:
+        specifier: ^29.0.0
+        version: 29.7.0(@types/node@24.0.3)(ts-node@10.9.2(@types/node@24.0.3)(typescript@5.8.3))
+      typescript:
+        specifier: ^5.0.0
+        version: 5.8.3
+
   packages/shared-utils:
     devDependencies:
       '@types/jest':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,10 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
   },
   "include": ["lambdas/**/*", "packages/**/*"],
   "exclude": ["node_modules", "dist"]
 }
+ 


### PR DESCRIPTION
## Description

This PR introduces the new `@newriive/common-types` package to the monorepo. The package provides TypeScript types and interfaces shared across multiple lambdas and packages, along with sample data and type tests.

## Type of change

- [x] New feature (shared types package)
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## Checklist

- [x] Added `@newriive/common-types` package with its own `package.json`, `tsconfig.json`, and `README.md`
- [x] Defined `User`, `ChecklistGroup`, and `ChecklistItem` types in separate files and re-exported via `index.ts`
- [x] Added sample JSON data for each type in `tests/`
- [x] Added tests to validate type compatibility with sample data
- [x] Updated root `tsconfig.json` to enable `resolveJsonModule` for JSON imports
- [x] Updated `pnpm-lock.yaml` for new workspace package

## How Has This Been Tested?

- Ran `pnpm build` and `pnpm test` in the `common-types` package
- Verified type compatibility and sample data usage

## Additional context

- This package enables consistent type sharing and validation across the monorepo
- See the new `README.md` in `packages/common-types` for usage and development instructions
